### PR TITLE
35-Add-data-versioning-with-DVC

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ wandb
 .pytest_cache
 .coverage
 .tox
+/data

--- a/data.dvc
+++ b/data.dvc
@@ -1,0 +1,13 @@
+md5: 4253407e66290f8606794addb8b78ef5
+frozen: true
+deps:
+- path: data
+  repo:
+    url: https://huggingface.co/datasets/rojberr/tree-classification-irim-dataset
+    rev_lock: 9fa3f02b9dfc56740d633d01c5c6eced2c9b2614
+outs:
+- md5: d7dc4e6956ca58cd4b58b55463c4aeeb.dir
+  size: 24807690251
+  nfiles: 18
+  hash: md5
+  path: data


### PR DESCRIPTION
**This PR does the following:**

data(dvc): Init dvc
* Track just dvc files from https://huggingface.co/datasets/rojberr/tree-classification-irim-dataset
* Add dvc ignore
* Update .gitignore to track jus dvc files not data itself

#35 