### PR TITLE
[TEST] Post test coverage

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -65,18 +65,18 @@ jobs:
                 run: tox
                 env:
                     PLATFORM: ${{ matrix.os }}
+            -   name: Upload artifacts
+                uses: actions/upload-pages-artifact@v3
+                with:
+                   path: ./htmlcov
 
-#    deploy:
-#        needs: test
-#        runs-on: ubuntu-latest
-#        permissions:
-#            pages: write
-#            id-token: write
-#        steps:
-#            -   name: Upload coverage report artifact
-#                uses: actions/upload-pages-artifact@v3
-#                with:
-#                    path: './htmlcov/'
-#            -   name: Deploy to GitHub Pages
-#                uses: actions/deploy-pages@v4
-#                id: deployment
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        needs: pytest
+        steps:
+            -   name: Deploy to GitHub Pages
+                id: deployment
+                uses: actions/deploy-pages@v4


### PR DESCRIPTION
A static site will be created using GitHub Pages to display test coverage reports. The test workflow will be updated to upload artifacts from the pytest coverage directory (`./htmlcov`), enabling automatic deployment of the coverage reports.