### PR TITLE
Add cuDNN backend and fix confusion matrix

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -110,16 +110,15 @@ def main():
         log_model=True
     )
 
-    bf16_supported = torch.cuda.is_bf16_supported()
-    precision = "bf16-mixed" if bf16_supported else "16-mixed"
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cudnn.enabled = True
 
     trainer = Trainer(
         logger=wandb_logger,
         max_epochs=max_epochs,
         accelerator=device,
         devices=1,
-        callbacks=callbacks,
-        precision=precision
+        callbacks=callbacks
     )
 
     trainer.fit(model, datamodule)

--- a/src/main.py
+++ b/src/main.py
@@ -89,9 +89,6 @@ def main():
 
     # ================================ OPTIMIZING THE MODEL ==================================== #
 
-    bf16_supported = torch.cuda.is_bf16_supported()
-    precision = "bf16-mixed" if bf16_supported else "16-mixed"
-
     torch.backends.cudnn.benchmark = True
     torch.backends.cudnn.enabled = True
 
@@ -126,7 +123,7 @@ def main():
         accelerator=device,
         devices=1,
         callbacks=callbacks,
-        precision=precision
+        precision="16-mixed"
     )
 
     trainer.fit(model, datamodule)

--- a/src/main.py
+++ b/src/main.py
@@ -92,7 +92,7 @@ def main():
     torch.backends.cudnn.benchmark = True
     torch.backends.cudnn.enabled = True
 
-    model = torch.compile(model)
+    model = torch.compile(model, backend="eager")
 
     # ====================================== TRAINING ========================================== #
     max_epochs = config["training"]["max_epochs"]

--- a/src/main.py
+++ b/src/main.py
@@ -92,7 +92,8 @@ def main():
     torch.backends.cudnn.benchmark = True
     torch.backends.cudnn.enabled = True
 
-    model = torch.compile(model, backend="eager")
+    bf16_supported = torch.cuda.is_bf16_supported()
+    precision = "bf16-mixed" if bf16_supported else "16-mixed"
 
     # ====================================== TRAINING ========================================== #
     max_epochs = config["training"]["max_epochs"]
@@ -123,7 +124,7 @@ def main():
         accelerator=device,
         devices=1,
         callbacks=callbacks,
-        precision="16-mixed"
+        precision=precision
     )
 
     trainer.fit(model, datamodule)

--- a/src/main.py
+++ b/src/main.py
@@ -87,14 +87,6 @@ def main():
         freeze=freeze
     )
 
-    # ================================ OPTIMIZING THE MODEL ==================================== #
-
-    torch.backends.cudnn.benchmark = True
-    torch.backends.cudnn.enabled = True
-
-    bf16_supported = torch.cuda.is_bf16_supported()
-    precision = "bf16-mixed" if bf16_supported else "16-mixed"
-
     # ====================================== TRAINING ========================================== #
     max_epochs = config["training"]["max_epochs"]
     device = config["device"] if torch.cuda.is_available() else "cpu"
@@ -117,6 +109,9 @@ def main():
         project='ghost-irim',
         log_model=True
     )
+
+    bf16_supported = torch.cuda.is_bf16_supported()
+    precision = "bf16-mixed" if bf16_supported else "16-mixed"
 
     trainer = Trainer(
         logger=wandb_logger,

--- a/src/main.py
+++ b/src/main.py
@@ -87,6 +87,12 @@ def main():
         freeze=freeze
     )
 
+    # ================================ OPTIMIZING THE MODEL ==================================== #
+
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cudnn.enabled = True
+    model = torch.compile(model)
+
     # ====================================== TRAINING ========================================== #
     max_epochs = config["training"]["max_epochs"]
     device = config["device"] if torch.cuda.is_available() else "cpu"
@@ -115,7 +121,8 @@ def main():
         max_epochs=max_epochs,
         accelerator=device,
         devices=1,
-        callbacks=callbacks
+        callbacks=callbacks,
+        precision="bf16-mixed"
     )
 
     trainer.fit(model, datamodule)

--- a/src/main.py
+++ b/src/main.py
@@ -89,8 +89,12 @@ def main():
 
     # ================================ OPTIMIZING THE MODEL ==================================== #
 
+    bf16_supported = torch.cuda.is_bf16_supported()
+    precision = "bf16-mixed" if bf16_supported else "16-mixed"
+
     torch.backends.cudnn.benchmark = True
     torch.backends.cudnn.enabled = True
+
     model = torch.compile(model)
 
     # ====================================== TRAINING ========================================== #
@@ -122,7 +126,7 @@ def main():
         accelerator=device,
         devices=1,
         callbacks=callbacks,
-        precision="bf16-mixed"
+        precision=precision
     )
 
     trainer.fit(model, datamodule)

--- a/src/visualization_functions.py
+++ b/src/visualization_functions.py
@@ -162,6 +162,10 @@ def get_confusion_matrix(model_output, targets, filepath=Path.cwd() / "src" / "p
         ax.set_yticks(np.arange(len(class_names)))
         ax.set_xticklabels(class_names)
         ax.set_yticklabels(class_names)
+
+        # Make sure that long label names are also visible
+        for label in ax.get_xticklabels():
+            label.set_rotation(45)
     else:
         ax.set_xticks(np.arange(num_classes))
         ax.set_yticks(np.arange(num_classes))


### PR DESCRIPTION
In this branch I tested adding:
- `torch.compile`
- Mixed precision
- cuDNN backedn

It turned out that both mixed precision and `torch.compile` didn't work with our setup. Faster calculations with mixed precision are not supported by the lightning.ai GPUs and `torch.compile` doesn't work with logging. However, by adding cuDNN backend I was able to speed up the training by about 20%. 

I also fixed a bug with the confusion matrix. Before, the tick labels on the x axis were overlapping so I turned them 45 degrees to make them visible.

#116