### PR TITLE
Add-codeowners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "rojberr"
     labels:
       - "dependencies"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Notify and request @rojberr for review when PR opened for files
+requirements.txt            @rojberr #This is for as long as we do not allow auto dependeabot PR
+unix-requirements..txt      @rojberr #See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Notify and request @rojberr for review when PR opened for files
-requirements.txt            @rojberr #This is for as long as we do not allow auto dependeabot PR
-unix-requirements..txt      @rojberr #See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+requirements.txt            @rojberr #This is for as long as we do not allow auto dependabot PR
+unix-requirements.txt      @rojberr #See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners


### PR DESCRIPTION
build(): Add CODEOWNERS

* Remove reviewer from dependabot conf
* Add CODEOWNER to notify @rojberr when dependabot PR created

See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/