### PR TITLE
[TEST] Use ruff as code formatter and linter

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,11 @@
+name: Linting & Formatting Check
+on: 
+    pull_request:
+
+jobs:
+    
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,46 @@
+[tool.ruff]
+line-length = 200
+target-version = "py310"
+# fix = true
+
+[tool.ruff.lint]
+select = [
+  # pycodestyle
+  "E", "W",
+  # flake8-2020
+  "YTT",
+  # flake8-bugbear
+  "B",
+  # flake8-quotes
+#   "Q",
+  # flake8-debugger
+  "T10",
+  # flake8-gettext
+  "INT",
+  # flake8-pytest-style
+  "PT",
+  # flake8-pyi
+  "PYI",
+  # flake8-type-checking
+  "TC",
+  # Ruff-specific rules
+  "RUF",
+  # flake8-bandit: exec-builtin
+  "S102",
+  # flake8-logging-format
+  "G",
+  # flake8-future-annotations
+  "FA",
+  # flake8-slots
+  "SLOT",
+  # flake8-raise
+  "RSE"
+]
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = "dynamic"
+
 [tool.coverage.run]
 omit = [
     "src/__init__.py",


### PR DESCRIPTION
**User story:**
**As a developer,**
**I want to integrate Ruff into the project as a linter and formatter,**
**So that we can benefit from significantly faster linting, better configuration support, and avoid time-consuming formatting debates.**

**Acceptance Criteria:**

* [ ] Ruff is added as a development dependency.
* [ ] Ruff is configured via `pyproject.toml`.
* [ ] Existing linting (e.g., flake8) is removed.
* [ ] CI pipeline is updated to use Ruff for linting and formatting checks.

**Definition of Done:**

* [ ] All acceptance criteria are met.
* [ ] Code is reviewed and approved.
* [ ] Necessary tests are written and pass.
* [ ] Documentation is updated, if applicable (e.g., contributing guide).
* [ ] Feature is deployed to the main development environment.

**Description:**
Ruff is a modern Python linter and formatter that is up to 100x faster than traditional tools like flake8. It supports configuration via `pyproject.toml`, providing a single, centralized config format that flake8 lacks. Additionally, Ruff functions as both a linter and a formatter, reducing the need for separate tools like `black`. By adopting Ruff, we streamline the development workflow, reduce CI time, and eliminate unnecessary discussions around formatting by enforcing consistent styles automatically.